### PR TITLE
fix: Persist SelectedDocument id after create to prevent duplicate writes

### DIFF
--- a/fframe/lib/controllers/selection_state_controller.dart
+++ b/fframe/lib/controllers/selection_state_controller.dart
@@ -594,6 +594,8 @@ class SelectedDocument<T> {
             fromFirestore: documentConfig.fromFirestore,
             toFirestore: documentConfig.toFirestore,
           );
+    _id = docId; //persist the written id
+    _isNew = false; //update() previously never flipped this; keep it consistent with save()
     //Update the fingerprint
     _fingerPrint = _createFingerPrint();
   }
@@ -641,6 +643,7 @@ class SelectedDocument<T> {
         //Success
         Console.log("Save was successfull", scope: "fframeLog.DocumentScreen.save", level: LogLevel.dev);
         _isNew = false;
+        _id = docId; //persist the id actually written so a re-save updates in place instead of duplicating
         if (closeAfterSave) {
           if (context.mounted) {
             close(context: context, skipWarning: true);


### PR DESCRIPTION
## Problem

`SelectedDocument` freezes its `_id` at `createNew()` time from an **empty** model, and never writes back the real id it computes at save time. If the same in-memory new-document instance is saved a second time, fframe takes the `updateDocument(_id, merge:true)` branch with the **stale** id, and `.set(merge:true)` writes a **duplicate** document at the wrong id instead of updating the one it just created. This is the root cause of recurring duplicate + `null_null_null_null_null` / random-id documents observed in a downstream consumer app.

## Fix

Persist the id actually written after a successful CREATE, so any subsequent save on the same instance is idempotent (updates in place, no duplicate):

- **`save()`** — in the `if (saveResult.result)` success block, next to `_isNew = false;`, add `_id = docId;`
- **`update()`** — after the create/update await, add `_id = docId;` and `_isNew = false;` (update previously never flipped `isNew`)

3 lines added, no formatting churn.

## Why it's safe

- **Existing (non-new) saves unaffected:** for a loaded doc `docId == documentId == _id` already, so `_id = docId` is a no-op. Behaviour only changes for the new-doc-second-save case.
- **First create still writes the recomputed composed id** (`docId` from `_createNewDocumentId(data)` while `isNew`), unchanged.

## Verification

- `flutter analyze` on the file: 0 errors, 0 warnings (remaining items are pre-existing `info` lints, none on the changed lines).
- Reason-through: after the fix, a second `save()` runs with `isNew == false` and `docId == documentId == _id == <created composed id>`, so `updateDocument` targets the real id and updates in place.
- No automated test added: `DatabaseService` hard-codes `FirebaseFirestore.instance` / `FirebaseAuth.instance` with no injection seam, there are no Firestore/auth mocking dev-deps, and `save()` needs a mounted widget tree. End-to-end confirmation happens in the downstream consumer app after `flutter pub upgrade fframe`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
